### PR TITLE
add spec / fix warning / use CrossroadRegex

### DIFF
--- a/PathToRegex.podspec
+++ b/PathToRegex.podspec
@@ -1,0 +1,17 @@
+Pod::Spec.new do |s|
+  s.name         = "PathToRegex"
+  s.version      = "0.2.2"
+  s.summary      = "A Swift library translating paths with wildcards into regular expressions"
+  s.homepage     = "https://github.com/crossroadlabs/PathToRegex"
+  s.license      = { :type => 'LGPL v3', :file => 'LICENSE' }
+  s.author       = { "Crossroad Labs" => "daniel@crossroadlabs.xyz" }
+  s.source       = { :git => "https://github.com/crossroadlabs/PathToRegex.git", :tag => "#{s.version}" }
+  s.source_files = 'PathToRegex/**/*'
+
+  s.ios.deployment_target = '8.0'
+  s.osx.deployment_target = '10.9'
+  s.tvos.deployment_target = '9.0'
+  s.watchos.deployment_target = '2.0'
+
+  s.dependency 'CrossroadRegex', '~> 0.7.0'
+end


### PR DESCRIPTION
following up #4 
Regex dep has been renamed CrossroadRegex am I right?
- I added  a #if to use the appropriate lib name (_Crossroad_**Regex**)
- I fixed a warning to make `pod lib lint` pass

Let me know what you think!
